### PR TITLE
fix: add multi-root workspace support (closes #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "npm-visual-manager" extension will be documented in this file.
 
+## [1.6.0] - 2026-03-31
+
+### Fixed
+- **Multi-root Workspace Support**: Resolves issue #2
+  - Previously: Only the first workspace folder was scanned, so projects in other roots were never shown
+  - Now: All workspace folders in a `.code-workspace` are scanned and their packages are listed together
+  - Also fixed: Subdirectories with a `package.json` are now recursed into, so nested packages inside monorepo workspaces are correctly detected
+
 ## [1.5.0] - 2026-03-30
 
 ### Added

--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -27,16 +27,12 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
 
-      let workspaceRoot = workspaceFolders[0]!.uri.fsPath;
+      // Collect all workspace folder paths for multi-root workspace support
+      const allWorkspaceRoots = workspaceFolders.map(f => f.uri.fsPath);
       let preferredProjectPath: string | undefined;
 
       const activeUri = resource || vscode.window.activeTextEditor?.document.uri;
       if (activeUri && activeUri.scheme === 'file') {
-        const folder = vscode.workspace.getWorkspaceFolder(activeUri);
-        if (folder) {
-          workspaceRoot = folder.uri.fsPath;
-        }
-
         const isPackageJson = path.basename(activeUri.fsPath).toLowerCase() === 'package.json';
         preferredProjectPath = isPackageJson ? path.dirname(activeUri.fsPath) : activeUri.fsPath;
       }
@@ -45,7 +41,7 @@ export function activate(context: vscode.ExtensionContext): void {
         await NpmGuiManagerPanel.createOrShow(
           context.extensionUri,
           context.globalStorageUri,
-          workspaceRoot,
+          allWorkspaceRoots,
           preferredProjectPath
         );
       } catch (error) {

--- a/src/core/webviewPanel.ts
+++ b/src/core/webviewPanel.ts
@@ -10,7 +10,7 @@ import { findPackageJson, readPackageJson, extractDependencies } from '../servic
 import { getPackageDetails, getPackageVersions, getSemverUpdateType, setGlobalCache } from '../services/npmService';
 import { getCache, VersionCache } from '../services/cacheService';
 import { getIgnoreService } from '../services/ignoreService';
-import { findAllProjects, Project } from '../services/workspaceService';
+import { findAllProjectsMultiRoot, Project } from '../services/workspaceService';
 import {
   runAudit,
   hasVulnerabilities,
@@ -45,13 +45,16 @@ export class NpmGuiManagerPanel {
   public static async createOrShow(
     extensionUri: vscode.Uri,
     globalStorageUri: vscode.Uri,
-    workspaceRoot: string,
+    workspaceRoots: string | string[],
     preferredProjectPath?: string
   ): Promise<void> {
     const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined;
 
-    // Find all projects in workspace
-    const discoveredProjects = await findAllProjects(workspaceRoot);
+    const roots = Array.isArray(workspaceRoots) ? workspaceRoots : [workspaceRoots];
+    const workspaceRoot = roots[0]!;
+
+    // Find all projects across all workspace roots (multi-root workspace support)
+    const discoveredProjects = await findAllProjectsMultiRoot(roots);
     const projects = await NpmGuiManagerPanel._withPreferredProject(
       discoveredProjects,
       workspaceRoot,

--- a/src/services/workspaceService.ts
+++ b/src/services/workspaceService.ts
@@ -66,6 +66,8 @@ async function searchDirectories(
             path: fullPath,
             relativePath,
           });
+          // Continue recursing into this directory to find nested packages (e.g. monorepo workspaces)
+          await searchDirectories(fullPath, workspaceRoot, currentDepth + 1, maxDepth, projects);
         } else {
           // Recurse into subdirectory
           await searchDirectories(fullPath, workspaceRoot, currentDepth + 1, maxDepth, projects);
@@ -84,6 +86,27 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Find all projects across multiple workspace roots (multi-root workspace support)
+ */
+export async function findAllProjectsMultiRoot(workspaceRoots: string[]): Promise<Project[]> {
+  const allProjects: Project[] = [];
+  const seen = new Set<string>();
+
+  for (const root of workspaceRoots) {
+    const projects = await findAllProjects(root);
+    for (const project of projects) {
+      const normalized = path.normalize(project.path).toLowerCase();
+      if (!seen.has(normalized)) {
+        seen.add(normalized);
+        allProjects.push(project);
+      }
+    }
+  }
+
+  return allProjects;
 }
 
 async function getProjectName(packageJsonPath: string): Promise<string> {


### PR DESCRIPTION
- Pass all workspace folders to createOrShow instead of only workspaceFolders[0]
- Add findAllProjectsMultiRoot() to scan multiple roots and deduplicate results
- Fix searchDirectories to recurse into directories that contain package.json
- Add [1.6.0] entry to CHANGELOG.md